### PR TITLE
Speed up job submission by checking for proxy

### DIFF
--- a/python/processing.py
+++ b/python/processing.py
@@ -874,7 +874,7 @@ class Task:
                 + self.scheduler.user + '@' +  self.scheduler.host + ':' + self.logs
             os.system(cmd)
             cmd = "ssh -x " + self.scheduler.user + '@' +  self.scheduler.host \
-                + ' \"voms-proxy-init --valid 168:00 -voms cms >& /dev/null\" '
+                + ' \"voms-proxy-info -exists || voms-proxy-init --valid 168:00 -voms cms >& /dev/null\" '
             os.system(cmd)
 
 #---------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This voms-proxy-init seemed to be the slowest part of the submission process. It might be worth throwing in this check for all the other places it shows up too. I realize we sort of want to throttle jobs submissions, but I don't think over three hours for just submitting a small slimmer is very good.